### PR TITLE
[DOCS] create ns during helm vault installation

### DIFF
--- a/openshift-gitops/vault.md
+++ b/openshift-gitops/vault.md
@@ -2,7 +2,7 @@
 ```
 helm repo add hashicorp https://helm.releases.hashicorp.com
 helm repo update
-helm -n vault install vault hashicorp/vault --set "global.openshift=true" --set "server.dev.enabled=true"
+helm -n vault install vault hashicorp/vault --set "global.openshift=true" --set "server.dev.enabled=true" --create-namespace
 ```
 
 ## Vault setup  - TODO - Production Setup


### PR DESCRIPTION
➜  kong-cp git:(structure) helm -n vault install vault hashicorp/vault --set "global.openshift=true" --set "server.dev.enabled=true"
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/cmwylie19/.kube/config
Error: INSTALLATION FAILED: create: failed to create: namespaces "vault" not found

This PR creates the namespace